### PR TITLE
Updating 'data' to 'email_data'

### DIFF
--- a/sendwithus/__init__.py
+++ b/sendwithus/__init__.py
@@ -86,14 +86,14 @@ class api:
 
         return r
 
-    def send(self, email_name, email_to, data=None):
-        if not data:
-            data = {}
+    def send(self, email_name, email_to, email_data=None):
+        if not email_data:
+            email_data = {}
 
         payload = {
             'email_name':  email_name,
             'email_to': email_to,
-            'email_data': data
+            'email_data': email_data
         }
 
         return self._api_request(self.SEND_ENDPOINT, payload=payload)

--- a/sendwithus/test/__init__.py
+++ b/sendwithus/test/__init__.py
@@ -12,8 +12,8 @@ class TestAPI(unittest.TestCase):
         self.api = api(self.API_KEY, **self.options) 
 
     def test_send(self):
-        data = {'name': 'Jimmy'}
-        self.api.send('test', 'test@sendwithus.com', data=data)
+        email_data = {'name': 'Jimmy'}
+        self.api.send('test', 'test@sendwithus.com', email_data=email_data)
         self.assertTrue(True)
 
 if __name__ == '__main__':


### PR DESCRIPTION
The website says 'email_data', but the provided python library uses
'data'. 'email_data' matches the rest api, matches the website, and is
a bit more consistent.
