### PR TITLE
Fix absolute import.

### DIFF
--- a/sendwithus/__init__.py
+++ b/sendwithus/__init__.py
@@ -9,8 +9,8 @@ import requests
 import warnings
 import base64
 
-from encoder import SendwithusJSONEncoder
-from version import version
+from .encoder import SendwithusJSONEncoder
+from .version import version
 
 
 LOGGER_FORMAT = '%(asctime)-15s %(message)s'


### PR DESCRIPTION
Importing the module yields:

``` python
File "/tmp/sendwithus_python/sendwithus/__init__.py", line 12, in <module>
    from encoder import SendwithusJSONEncoder
ImportError: No module named 'encoder'
```

Those imports only worked from inside the module.
