### PR TITLE
Replace basestring with str for python 3 compatibility.

### DIFF
--- a/sendwithus/__init__.py
+++ b/sendwithus/__init__.py
@@ -259,7 +259,7 @@ class api:
             email_data = {}
 
         # for backwards compatibility, will be removed
-        if isinstance(recipient, basestring):
+        if isinstance(recipient, str):
             warnings.warn(
                 "Passing email directly for recipient is deprecated",
                 DeprecationWarning)


### PR DESCRIPTION
Python 3 portability fix, makes at least send() on 3.3. AFAICT this doesn't break anything for the previous version, but my python2 is rusty so feel free to correct me if needed.
