### PR TITLE
Add headers support to send()

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,18 @@ print r.status_code
 # 200
 ```
 
+### Optional Headers
+
+```python
+r = api.send(
+    email_id='YOUR-EMAIL-ID',
+    recipient={'name': 'Matt',
+                'address': 'us@sendwithus.com'},
+    headers={'X-HEADER-ONE': 'header-value'})
+print r.status_code
+# 200
+```
+
 ### Optional ESP Account
 
 ```python

--- a/sendwithus/__init__.py
+++ b/sendwithus/__init__.py
@@ -318,6 +318,7 @@ class api:
             cc=None,
             bcc=None,
             tags=[],
+            headers={},
             esp_account=None,
             locale=None,
             email_version_name=None,
@@ -358,6 +359,12 @@ class api:
                 logger.error(
                     'kwarg tags must be type(list), got %s' % (type(tags)))
             payload['tags'] = tags
+
+        if headers:
+            if not type(headers) == dict:
+                logger.error(
+                    'kwarg headers must be type(dict), got %s' % (type(headers)))
+            payload['headers'] = headers
 
         if esp_account:
             if not isinstance(esp_account, string_types):

--- a/sendwithus/test/__init__.py
+++ b/sendwithus/test/__init__.py
@@ -215,6 +215,22 @@ class TestAPI(unittest.TestCase):
             tags='bad')
         self.assertFail(result)
 
+    def test_send_headers(self):
+        result = self.api.send(
+            self.EMAIL_ID,
+            self.recipient,
+            email_data = self.email_data,
+            headers={'X-HEADER-ONE': 'header-value'})
+        self.assertSuccess(result)
+
+    def test_send_headers_invalid(self):
+        result = self.api.send(
+            self.EMAIL_ID,
+            self.recipient,
+            email_data = self.email_data,
+            headers='X-HEADER-ONE')
+        self.assertFail(result)
+
     def test_drip_deactivate(self):
         result = self.api.drip_deactivate(self.email_address)
         self.assertSuccess(result)


### PR DESCRIPTION
Support for providing an optional headers dictionary is available in the SWU API, but was not yet supported in the python api client.