### PR TITLE
Python 3 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.pyc
 *.swo
 *.swp
+__pycache__
 local_settings.py
 
 # pypi building stuff
@@ -16,3 +17,6 @@ build/*
 # IntelliJ
 .idea
 *.iml
+
+# testing/tox
+.tox/

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: python
 python:
   - "2.6"
   - "2.7"
+  - "3.4"
+  - "3.5"
 
 install: "pip install -r requirements.txt --use-mirrors"
 

--- a/README.md
+++ b/README.md
@@ -381,6 +381,15 @@ api.render('tem_12345', { "amount": "$12.00" }, 'French-Version', strict=False)
 ## to run tests
     python setup.py test
 
+### Testing multiple python versions
+This assumes you have [tox](https://testrun.org/tox/latest/) installed and used
+[pyenv](https://github.com/yyuu/pyenv) to install multiple versions of python.
+
+Once all the supported python versions are installed simply run:
+
+    tox
+
+This will run the tests against all the versions specified in `tox.ini`.
+
 ### packaging (internal)
         python setup.py sdist upload
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-requests==1.2.3
+requests==2.0.0
 six==1.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 requests==1.2.3
 six==1.9.0
-wsgiref==0.1.2

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,9 @@ setup(
     classifiers=[
         "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.4",
+        "Programming Language :: Python :: 3.5",
         "License :: OSI Approved :: Apache Software License",
         "Development Status :: 5 - Production/Stable",
         "Topic :: Communications :: Email"

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     long_description=long_description,
     test_suite="sendwithus.test",
     install_requires=[
-        "requests >= 1.1.0",
+        "requests >= 2.0.0",
         "six >= 1.9.0"
     ],
     classifiers=[

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py34, py35
+envlist = py26, py27, py34, py35
 skip_missing_interpreters = true
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,6 @@
+[tox]
+envlist = py27, py34, py35
+skip_missing_interpreters = true
+
+[testenv]
+commands = python setup.py test

--- a/tox.ini
+++ b/tox.ini
@@ -3,4 +3,5 @@ envlist = py26, py27, py34, py35
 skip_missing_interpreters = true
 
 [testenv]
+deps = -r{toxinidir}/requirements.txt
 commands = python setup.py test


### PR DESCRIPTION
Added the necessary config file for `tox` and updated the `README` to explain how to test multiple python interpreter versions.

**There seems to be a few issues to resolve before python 3 compatibility is ready to be merged.**