### PR TITLE
Add  file content read for Python 3 (keep compat with Python 2.7)

### DIFF
--- a/sendwithus/__init__.py
+++ b/sendwithus/__init__.py
@@ -10,6 +10,7 @@ import sys
 import warnings
 
 import requests
+import six
 from six import string_types
 
 from .encoder import SendwithusJSONEncoder
@@ -405,11 +406,9 @@ class api:
                         type(email_version_name)))
             payload['version_name'] = email_version_name
 
-        is_py3 = sys.version_info > (3, 0, 0)
-
         if inline:
             if isinstance(inline, file):
-                image = ({'id': inline.name, 'data': base64.b64encode(inline.read()).decode() if is_py3 else base64.b64encode(inline.read())})
+                image = ({'id': inline.name, 'data': base64.b64encode(inline.read()).decode() if six.PY3 else base64.b64encode(inline.read())})
 
                 payload['inline'] = image
 
@@ -421,7 +420,7 @@ class api:
             file_list = []
             if isinstance(files, list):
                 for f in files:
-                    file_list.append({'id': f.name, 'data': base64.b64encode(f.read()).decode() if is_py3 else base64.b64encode(f.read())})
+                    file_list.append({'id': f.name, 'data': base64.b64encode(f.read()).decode() if six.PY3 else base64.b64encode(f.read())})
 
                 payload['files'] = file_list
 

--- a/sendwithus/__init__.py
+++ b/sendwithus/__init__.py
@@ -4,16 +4,17 @@ For more information, visit http://www.sendwithus.com
 """
 
 import base64
-import logging
 import json
-import requests
-from six import string_types
+import logging
+import sys
 import warnings
 
-from .encoder import SendwithusJSONEncoder
-from .version import version
-from .exceptions import APIError, AuthenticationError, ServerError
+import requests
+from six import string_types
 
+from .encoder import SendwithusJSONEncoder
+from .exceptions import APIError, AuthenticationError, ServerError
+from .version import version
 
 LOGGER_FORMAT = '%(asctime)-15s %(message)s'
 logger = logging.getLogger('sendwithus')
@@ -404,9 +405,11 @@ class api:
                         type(email_version_name)))
             payload['version_name'] = email_version_name
 
+        is_py3 = sys.version_info > (3, 0, 0)
+
         if inline:
             if isinstance(inline, file):
-                image = ({'id': inline.name, 'data': base64.b64encode(inline.read())})
+                image = ({'id': inline.name, 'data': base64.b64encode(inline.read()).decode() if is_py3 else base64.b64encode(inline.read())})
 
                 payload['inline'] = image
 
@@ -418,7 +421,7 @@ class api:
             file_list = []
             if isinstance(files, list):
                 for f in files:
-                    file_list.append({'id': f.name, 'data': base64.b64encode(f.read())})
+                    file_list.append({'id': f.name, 'data': base64.b64encode(f.read()).decode() if is_py3 else base64.b64encode(f.read())})
 
                 payload['files'] = file_list
 


### PR DESCRIPTION
Allow Python 3 program to upload files in JSON format. Otherwise a `is not JSON serializable` error occure. 