### PR TITLE
Support passing in arguments to the underlying requests library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.pyc
 *.swo
 *.swp
+*.sublime-*
 __pycache__
 local_settings.py
 
@@ -20,3 +21,6 @@ build/*
 
 # testing/tox
 .tox/
+
+# virtualenv
+.venv


### PR DESCRIPTION
For example you can now pass in a `timeout` option like this:

```python
sendwithus_api.send(…, requests_kwargs={'timeout': '8'})
```

Did some minor PEP-8 fixes also.