### PR TITLE
Accept attachements with explicitly provided filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,8 @@ r = api.send(
     email_id='YOUR-EMAIL-ID',
     recipient={'name': 'Matt',
                'address': 'us@sendwithus.com'},
-    files=[(open('/home/Matt/report1.txt', 'r'), 'arbitrary_file_name.xyz')])
+    files=[{'file': open('/home/Matt/report1.txt', 'r'),
+            'filename': 'arbitrary_file_name.xyz'}])
 print r.status_code
 # 200
 ```

--- a/README.md
+++ b/README.md
@@ -191,6 +191,18 @@ print r.status_code
 # 200
 ```
 
+### Optional File Attachments With explicit file names
+
+```python
+r = api.send(
+    email_id='YOUR-EMAIL-ID',
+    recipient={'name': 'Matt',
+               'address': 'us@sendwithus.com'},
+    files=[(open('/home/Matt/report1.txt', 'r'), 'arbitrary_file_name.xyz')])
+print r.status_code
+# 200
+```
+
 ### Optional Inline Image
 
 ```python

--- a/sendwithus/__init__.py
+++ b/sendwithus/__init__.py
@@ -546,13 +546,17 @@ class api:
             file_list = []
             if isinstance(files, list):
                 for f in files:
-                    file_list.append({
-                        'id': f.name,
-                        'data': (
-                            base64.b64encode(f.read()).decode()
-                            if six.PY3 else base64.b64encode(f.read())
-                        )
-                    })
+                    if isinstance(f, tuple):
+                        file_obj, file_name = f
+                    else:
+                        file_obj = f
+                        file_name = f.name
+
+                    file_list.append(
+                        {'id': file_name,
+                         'data': base64.b64encode(file_obj.read()).decode()
+                         if six.PY3 else base64.b64encode(file_obj.read())}
+                    )
 
                 payload['files'] = file_list
 

--- a/sendwithus/__init__.py
+++ b/sendwithus/__init__.py
@@ -546,8 +546,12 @@ class api:
             file_list = []
             if isinstance(files, list):
                 for f in files:
-                    if isinstance(f, tuple):
-                        file_obj, file_name = f
+                    if isinstance(f, dict):
+                        file_obj = f['file']
+                        if 'filename' in f:
+                            file_name = f['filename']
+                        else:
+                            file_name = file_obj.name
                     else:
                         file_obj = f
                         file_name = f.name

--- a/test_base.py
+++ b/test_base.py
@@ -245,7 +245,7 @@ def file():
         yield tempf
 
 
-def test_send_with_files(api, email_id, recipient, email_data, file):
+def test_send_with_files_valid(api, email_id, recipient, email_data, file):
         result = api.send(
             email_id,
             recipient,
@@ -261,9 +261,34 @@ def test_send_with_files_explicit_filename(api, email_id,
             email_id,
             recipient,
             email_data=email_data,
-            files=[(file, 'filename.pdf')])
+            files=[{'file': file,
+                    'filename': 'filename.pdf'}]
+        )
 
         assert result.status_code == 200
+
+
+def test_send_with_files_valid_1(api, email_id,
+                                 recipient, email_data, file):
+    result = api.send(
+        email_id,
+        recipient,
+        email_data=email_data,
+        files=[{'file': file}]
+    )
+
+    assert result.status_code == 200
+
+
+def test_send_with_files_invalid(api, email_id,
+                                 recipient, email_data, file):
+    with pytest.raises(KeyError):
+        api.send(
+            email_id,
+            recipient,
+            email_data=email_data,
+            files=[{'filename': 'filename.pdf'}]
+        )
 
 
 def test_drip_deactivate(api, email_address):

--- a/test_base.py
+++ b/test_base.py
@@ -1,8 +1,11 @@
 import json
 import decimal
+import tempfile
 import time
 
 import pytest
+import six
+
 import sendwithus
 from sendwithus.exceptions import APIError, AuthenticationError
 
@@ -230,6 +233,37 @@ def test_send_headers_invalid(api, email_id, recipient, email_data):
         headers='X-HEADER-ONE'
     )
     assert result.status_code != 200
+
+
+@pytest.yield_fixture
+def file():
+    with tempfile.NamedTemporaryFile() as tempf:
+        data = ('simple file content' + '\n') * 3
+        tempf.write(bytes(data, 'utf-8')) \
+            if six.PY3 else tempf.write(data)
+        tempf.seek(0)
+        yield tempf
+
+
+def test_send_with_files(api, email_id, recipient, email_data, file):
+        result = api.send(
+            email_id,
+            recipient,
+            email_data=email_data,
+            files=[file])
+
+        assert result.status_code == 200
+
+
+def test_send_with_files_explicit_filename(api, email_id,
+                                           recipient, email_data, file):
+        result = api.send(
+            email_id,
+            recipient,
+            email_data=email_data,
+            files=[(file, 'filename.pdf')])
+
+        assert result.status_code == 200
 
 
 def test_drip_deactivate(api, email_address):


### PR DESCRIPTION
Files can now be provided along with an explicit file name (compare readme).
This allows to not just use the name of the provided file, which can be quite overwhelming if its stored on aws for example.

Also added tests for sending with files.