### PR TITLE
Deprecate support for Customer Groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,17 +324,6 @@ api.customer_create('customer@example.com', data={'first_name': 'Matt'})
 api.customer_delete('customer@example.com')
 ```
 
-### Add Customer to a Group
-
-```python
-api.add_customer_to_group('customer@example.com', 'grp_1234')
-```
-
-### Remove Customer from a Group
-
-```python
-api.remove_customer_from_group('customer@example.com', 'grp_1234')
-```
 
 # Conversions
 
@@ -349,25 +338,6 @@ against your sent emails.
 api.customer_conversion('customer@example.com', revenue=10050)
 ```
 
-# Customer Groups
-
-### Create a Customer Group
-
-```python
-api.create_customer_group('group_name', 'sample group description')
-```
-
-### Delete a Customer Group
-
-```python
-api.delete_customer_group('grp_1234')
-```
-
-### Update a Customer Group
-
-```python
-api.update_customer_group('new_name', 'updated group description')
-```
 
 # Render
 

--- a/sendwithus/__init__.py
+++ b/sendwithus/__init__.py
@@ -52,9 +52,6 @@ class api:
     CUSTOMER_DETAILS_ENDPOINT = 'customers/%s'
     CUSTOMER_DELETE_ENDPOINT = 'customers/%s'
     CUSTOMER_CONVERSION_ENDPOINT = 'customers/%s/conversions'
-    CUSTOMER_GROUPS_ENDPOINT = 'customers/%s/groups/%s'
-    GROUPS_ENDPOINT = 'groups'
-    GROUP_ENDPOINT = 'groups/%s'
     DRIP_CAMPAIGN_LIST_ENDPOINT = 'drip_campaigns'
     DRIP_CAMPAIGN_ACTIVATE_ENDPOINT = 'drip_campaigns/%s/activate'
     DRIP_CAMPAIGN_DEACTIVATE_ENDPOINT = 'drip_campaigns/%s/deactivate'
@@ -600,76 +597,6 @@ class api:
             self.HTTP_POST,
             payload=payload,
             timeout=None
-        )
-
-    def create_customer_group(
-        self,
-        name,
-        description='',
-        timeout=None
-    ):
-        endpoint = self.GROUPS_ENDPOINT
-
-        payload = {
-            "name": name,
-            "description": description
-        }
-        return self._api_request(
-            endpoint,
-            self.HTTP_POST,
-            payload=payload,
-            timeout=timeout
-        )
-
-    def delete_customer_group(self, group_id, timeout=None):
-        endpoint = self.GROUP_ENDPOINT % group_id
-
-        return self._api_request(
-            endpoint,
-            self.HTTP_DELETE,
-            timeout=timeout
-        )
-
-    def update_customer_group(
-        self,
-        group_id,
-        name='',
-        description='',
-        timeout=None
-    ):
-        endpoint = self.GROUP_ENDPOINT % group_id
-
-        payload = {
-            "name": name,
-            "description": description
-        }
-
-        return self._api_request(
-            endpoint,
-            self.HTTP_PUT,
-            payload=payload,
-            timeout=timeout
-        )
-
-    def add_customer_to_group(self, email, group_id, timeout=None):
-        endpoint = self.CUSTOMER_GROUPS_ENDPOINT % (email, group_id)
-        return self._api_request(
-            endpoint,
-            self.HTTP_POST,
-            timeout=timeout
-        )
-
-    def remove_customer_from_group(
-        self,
-        email,
-        group_id,
-        timeout=None
-    ):
-        endpoint = self.CUSTOMER_GROUPS_ENDPOINT % (email, group_id)
-        return self._api_request(
-            endpoint,
-            self.HTTP_DELETE,
-            timeout=timeout
         )
 
     def list_drip_campaigns(self, timeout=None):

--- a/test_base.py
+++ b/test_base.py
@@ -396,36 +396,6 @@ def test_customer_conversion_revenue(api):
     assert_success(result)
 
 
-def test_customer_group_actions(api):
-    result = api.create_customer_group(
-        name=str(time.time()),
-        description='sample description'
-    )
-    assert_success(result)
-    group_id = json.loads(result.text)['group']['id']
-    result = api.update_customer_group(
-        group_id=group_id,
-        name='new+name' + str(time.time()),
-        description='new description'
-    )
-    assert_success(result)
-    result = api.add_customer_to_group(
-        email='customer@example.com',
-        group_id=group_id
-    )
-    assert_success(result)
-    result = api.delete_customer_group(group_id=group_id)
-    assert_success(result)
-
-
-def test_remove_customer_from_group(api):
-    result = api.remove_customer_from_group(
-        email='customer@example.com',
-        group_id='grp_1234'
-    )
-    assert_success(result)
-
-
 def test_list_drip_campaigns(api):
     """ Test listing drip campaigns. """
     result = api.list_drip_campaigns()


### PR DESCRIPTION
- Update README to reflect Customer Group API changes as the feature will soon be deprecated from all clients.
- Remove Customer Group API support from library