### PR TITLE
Deprecate conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,20 +325,6 @@ api.customer_delete('customer@example.com')
 ```
 
 
-# Conversions
-
-### Create a Customer Conversion event
-
-You can use the Conversion API to track conversion and revenue data events
-against your sent emails.
-
-**NOTE:** Revenue is in cents (eg. $100.50 = 10050)
-
-```python
-api.customer_conversion('customer@example.com', revenue=10050)
-```
-
-
 # Render
 
 ### Render a Template with data

--- a/sendwithus/__init__.py
+++ b/sendwithus/__init__.py
@@ -51,7 +51,6 @@ class api:
     CUSTOMER_CREATE_ENDPOINT = 'customers'
     CUSTOMER_DETAILS_ENDPOINT = 'customers/%s'
     CUSTOMER_DELETE_ENDPOINT = 'customers/%s'
-    CUSTOMER_CONVERSION_ENDPOINT = 'customers/%s/conversions'
     DRIP_CAMPAIGN_LIST_ENDPOINT = 'drip_campaigns'
     DRIP_CAMPAIGN_ACTIVATE_ENDPOINT = 'drip_campaigns/%s/activate'
     DRIP_CAMPAIGN_DEACTIVATE_ENDPOINT = 'drip_campaigns/%s/deactivate'
@@ -583,20 +582,6 @@ class api:
             endpoint,
             self.HTTP_DELETE,
             timeout=timeout
-        )
-
-    def customer_conversion(self, email, revenue=None, timeout=None):
-        endpoint = self.CUSTOMER_CONVERSION_ENDPOINT % email
-
-        payload = {
-            'revenue': revenue
-        }
-
-        return self._api_request(
-            endpoint,
-            self.HTTP_POST,
-            payload=payload,
-            timeout=None
         )
 
     def list_drip_campaigns(self, timeout=None):

--- a/sendwithus/version.py
+++ b/sendwithus/version.py
@@ -1,1 +1,1 @@
-version = '3.0.0'
+version = '4.0.0'

--- a/test_base.py
+++ b/test_base.py
@@ -383,19 +383,6 @@ def test_get_customer(api):
     assert_success(result)
 
 
-def test_customer_conversion(api):
-    result = api.customer_conversion('test+python@sendwithus.com')
-    assert_success(result)
-
-
-def test_customer_conversion_revenue(api):
-    result = api.customer_conversion(
-        'test+python@sendwithus.com',
-        revenue=1234
-    )
-    assert_success(result)
-
-
 def test_list_drip_campaigns(api):
     """ Test listing drip campaigns. """
     result = api.list_drip_campaigns()


### PR DESCRIPTION
- Update README to reflect Conversion API changes as the feature will soon be deprecated from all clients.
- Remove Conversion API support from library
