### PR TITLE
Fixed linter test errors

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ commands = py.test -n auto
 
 [testenv:lint]
 commands =
-    flake8 sendwithus/ test_base.py
+    flake8 sendwithus/test_base.py
     isort --verbose --recursive --diff sendwithus/
     isort --verbose --recursive --check-only sendwithus/
 deps =


### PR DESCRIPTION
Tox on Travis was failing because of a space in the commands directive in the `tox.ini file`. macOS handled it just fine, but I suspect GNU/Linux systems are more strict.

## Motivation and Context
It was unfortunate that we were getting the "build: failing" badge on the README.

## How Has This Been Tested?
Tested with Travis.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
