### PR TITLE
Adds locale param to email render call

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,7 +333,7 @@ The Render API allows you to render a template with data, using the exact same r
 `Strict` is set to `False` as a default, if `Strict=True` this API call will fail on any missing `email_data`.
 
 ```python
-api.render('tem_12345', { "amount": "$12.00" }, 'French-Version', strict=False)
+api.render('tem_12345', { "amount": "$12.00" }, locale='fr-FR', version_name='French-Version', strict=False)
 ```
 
 ### Expected Response

--- a/sendwithus/__init__.py
+++ b/sendwithus/__init__.py
@@ -699,20 +699,17 @@ class api:
         self,
         email_id,
         email_data,
-        locale=None,
         version_id=None,
         version_name=None,
         strict=False,
-        timeout=None
+        timeout=None,
+        locale=None
     ):
 
         payload = {
             "template_id": email_id,
             "template_data": email_data
         }
-
-        if locale:
-            payload['locale'] = locale
 
         if version_id:
             payload['version_id'] = version_id
@@ -722,6 +719,9 @@ class api:
 
         if strict:
             payload['strict'] = strict
+
+        if locale:
+            payload['locale'] = locale
 
         return self._api_request(
             self.RENDER_ENDPOINT,

--- a/sendwithus/__init__.py
+++ b/sendwithus/__init__.py
@@ -699,6 +699,7 @@ class api:
         self,
         email_id,
         email_data,
+        locale=None,
         version_id=None,
         version_name=None,
         strict=False,
@@ -709,6 +710,9 @@ class api:
             "template_id": email_id,
             "template_data": email_data
         }
+
+        if locale:
+            payload['locale'] = locale
 
         if version_id:
             payload['version_id'] = version_id

--- a/test_base.py
+++ b/test_base.py
@@ -370,6 +370,16 @@ def test_version_name(api, email_id, recipient, email_data):
     assert_success(result)
 
 
+def test_locale(api, email_id, recipient, email_data):
+    result = api.send(
+        email_id,
+        recipient,
+        email_data=email_data,
+        locale='sv-SE'
+    )
+    assert_success(result)
+
+
 def test_customer_actions(api):
     data = {'first_name': 'Python Client Unit Test'}
     result = api.customer_create('test+python@sendwithus.com', data)


### PR DESCRIPTION
## Description
This PR adds the locale param to the render email call.

## Motivation and Context
The sendwithus render API supports passing along a locale param, but it hasn't been added to the python client yet, this PR adds it.

## How Has This Been Tested?
Added a `test_locale` test to the test suite similar to the `test_version_name` test, but let me know if that is not sufficient.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
