### PR TITLE
Add translations capabilities to python client

### DIFF
--- a/README.md
+++ b/README.md
@@ -495,6 +495,26 @@ api.update_snippet(
 )
 ```
 
+# Internationalization (i18n) API
+
+### Get translation package (.pot file)
+
+```python
+api.get_translation_template(
+    `my_translation_tag`
+)
+```
+
+### Post translated strings and .po files
+
+```python
+with open('my_translation_file', 'rb') as f:
+    api.create_translation_file(
+        `my_translation_tag`,
+        f.read()
+    )
+```
+
 # Render
 
 ### Render a Template with data

--- a/sendwithus/__init__.py
+++ b/sendwithus/__init__.py
@@ -419,6 +419,26 @@ class api:
             timeout=timeout
         )
 
+    def get_translation_template(self, tag, timeout=None):
+        endpoint = self.TRANSLATION_TEMPLATE_ENDPOINT % tag
+
+        return self._api_request(
+            endpoint,
+            self.HTTP_GET,
+            timeout=timeout
+        )
+
+    def create_translation_file(self, tag, zipfile, timeout=None):
+        endpoint = self.TRANSLATION_FILE_ENDPOINT % tag
+
+        return self._api_request(
+            endpoint,
+            self.HTTP_POST,
+            data=zipfile,
+            headers={'Content-type': 'application/zip'},
+            timeout=timeout
+        )
+
     def drip_deactivate(self, email_address, timeout=None):
         payload = {'email_address': email_address}
 
@@ -676,27 +696,6 @@ class api:
         return self._api_request(
             endpoint,
             self.HTTP_GET,
-            timeout=timeout
-        )
-
-
-    def get_translation_template(self, tag, timeout=None):
-        endpoint = self.TRANSLATION_TEMPLATE_ENDPOINT % tag
-
-        return self._api_request(
-            endpoint,
-            self.HTTP_GET,
-            timeout=timeout
-        )
-
-    def create_translation_file(self, tag, zipfile, timeout=None):
-        endpoint = self.TRANSLATION_FILE_ENDPOINT % tag
-
-        return self._api_request(
-            endpoint,
-            self.HTTP_POST,
-            data=zipfile,
-            headers={'Content-type': 'application/zip'},
             timeout=timeout
         )
 

--- a/sendwithus/__init__.py
+++ b/sendwithus/__init__.py
@@ -687,22 +687,13 @@ class api:
             timeout=timeout
         )
 
-    def get_translation_file(self, tag, timeout=None):
-        endpoint = self.TRANSLATION_FILE_ENDPOINT % tag
-
-        return self._api_request(
-            endpoint,
-            self.HTTP_GET,
-            timeout=timeout
-        )
-
     def create_translation_file(self, tag, zipfile, timeout=None):
         endpoint = self.TRANSLATION_FILE_ENDPOINT % tag
 
         return self._api_request(
             endpoint,
             self.HTTP_POST,
-            payload=zipfile,
+            data=zipfile,
             timeout=timeout
         )
 

--- a/sendwithus/__init__.py
+++ b/sendwithus/__init__.py
@@ -57,6 +57,8 @@ class api:
     DRIP_CAMPAIGN_CUSTOMERS_ENDPOINT = 'drip_campaigns/%s/customers'
     DRIP_CAMPAIGN_STEP_CUSTOMERS_ENDPOINT = \
         'drip_campaigns/%s/steps/%s/customers'
+    TRANSLATION_TEMPLATE_ENDPOINT = 'i18n/pot/%s'
+    TRANSLATION_FILE_ENDPOINT = 'i18n/po/%s'
     BATCH_ENDPOINT = 'batch'
     RENDER_ENDPOINT = 'render'
 
@@ -672,6 +674,35 @@ class api:
         return self._api_request(
             endpoint,
             self.HTTP_GET,
+            timeout=timeout
+        )
+
+
+    def get_translation_template(self, tag, timeout=None):
+        endpoint = self.TRANSLATION_TEMPLATE_ENDPOINT % tag
+
+        return self._api_request(
+            endpoint,
+            self.HTTP_GET,
+            timeout=timeout
+        )
+
+    def get_translation_file(self, tag, timeout=None):
+        endpoint = self.TRANSLATION_FILE_ENDPOINT % tag
+
+        return self._api_request(
+            endpoint,
+            self.HTTP_GET,
+            timeout=timeout
+        )
+
+    def create_translation_file(self, tag, zipfile, timeout=None):
+        endpoint = self.TRANSLATION_FILE_ENDPOINT % tag
+
+        return self._api_request(
+            endpoint,
+            self.HTTP_POST,
+            payload=zipfile,
             timeout=timeout
         )
 

--- a/sendwithus/__init__.py
+++ b/sendwithus/__init__.py
@@ -172,6 +172,8 @@ class api:
         logger.debug('\tpath: %s' % path)
 
         data = self._build_payload(kwargs.get('payload'))
+        if not data:
+            data = kwargs.get('data')
         logger.debug('\tdata: %s' % data)
 
         req_kw = dict(
@@ -694,6 +696,7 @@ class api:
             endpoint,
             self.HTTP_POST,
             data=zipfile,
+            headers={'Content-type': 'application/zip'},
             timeout=timeout
         )
 


### PR DESCRIPTION
## Description
Added `get_translation_template` and `create_translation_file` to expose internationalization API capabilities to python client.

## Motivation and Context
This allows users to upload translation files programatically.

## How Has This Been Tested?
I've integrated this into my deployment process which uploads my templates, snippets, and translations in my github repository onto my SWU account.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
