### PR TITLE
Add locale on create customer and some CI housekeeping

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,6 @@ language: python
 
 matrix:
   include:
-  - python: 2.6
-    env:
-      - TOXENV='py26'
   - python: 2.7
     env:
       - TOXENV='py27'
@@ -14,7 +11,16 @@ matrix:
   - python: 3.5
     env:
       - TOXENV='py35'
-  - python: 3.5
+  - python: 3.6
+    env:
+      - TOXENV='py36'
+  - python: 3.7
+    env:
+      - TOXENV='py37'
+  - python: 3.8
+    env:
+      - TOXENV='py38'
+  - python: 3.8
     env:
       - TOXENV='lint'
 

--- a/README.md
+++ b/README.md
@@ -437,17 +437,17 @@ api.customer_details(
 )
 ```
 
-### Create/Update Customer
+### Create/Update Customer Locale
 
-You can use the same endpoint to create or update a customer. Sendwithus
-will perform a merge of the data on the customer profile, preferring the new data.
+You can use the same endpoint to create or update a customer. This is primarily
+used to associate a locale with an email address so Sendwithus can
+automatically send them the correct template. Note that if your templates are
+only in one language then you don't need to use this feature.
 
 ```python
 api.customer_create(
     'customer@example.com',
-    data={
-        'first_name': 'Matt'
-    }
+    locale="fr-FR"
 )
 ```
 

--- a/sendwithus/__init__.py
+++ b/sendwithus/__init__.py
@@ -565,7 +565,7 @@ class api:
             timeout=timeout
         )
 
-    def customer_create(self, email, data=None, timeout=None):
+    def customer_create(self, email, data=None, locale=None, timeout=None):
         if not data:
             data = {}
 
@@ -573,6 +573,9 @@ class api:
             'email': email,
             'data': data
         }
+
+        if locale:
+            payload["locale"] = locale
 
         return self._api_request(
             self.CUSTOMER_CREATE_ENDPOINT,

--- a/sendwithus/version.py
+++ b/sendwithus/version.py
@@ -1,1 +1,1 @@
-version = '5.1.0'
+version = '5.2.0'

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('README.md') as fp:
 
 setup(
     name='sendwithus',
-    version='5.1.0',
+    version='5.2.0',
     author='sendwithus',
     author_email='us@sendwithus.com',
     packages=find_packages(),

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{26,27,34,35,36,37,38}, lint
+envlist = py{27,34,35,36,37,38}, lint
 skip_missing_interpreters = true
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{26,27,34,35}, lint
+envlist = py{26,27,34,35,36,37,38}, lint
 skip_missing_interpreters = true
 
 [testenv]


### PR DESCRIPTION
The customer create endpoint is now primarily used for associating a locale (eg: "fr-FR") with an email address so the correct template is automatically sent in Sendwithus. The readme has been updated to reflect that.