### PR TITLE
Add a description content type for PyPI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ setup(
     license='LICENSE.txt',
     description='Python API client for sendwithus.com',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     test_suite="sendwithus.test",
     install_requires=[
         "requests >= 2.0.0",


### PR DESCRIPTION
A long_description_content_type is required since our README is in markdown
instead of restructured text. See here: [https://packaging.python.org/guides/making-a-pypi-friendly-readme/#including-your-readme-in-your-package-s-metadata](https://packaging.python.org/guides/making-a-pypi-friendly-readme/#including-your-readme-in-your-package-s-metadata)