### PR TITLE
Use explicit encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,7 +374,7 @@ api.start_on_drip_campaign(
 
 You may specify extra data to be merged into the templates in the drip campaign.
 
-*Note* — Any data provided in the `email_data` parameter for `start_on_drip_campaign()` will be used throughout the entire drip campaign.
+*Note* &emdash; Any data provided in the `email_data` parameter for `start_on_drip_campaign()` will be used throughout the entire drip campaign.
 
 ```python
 api.start_on_drip_campaign(
@@ -634,9 +634,9 @@ api = sendwithus.api(api_key='YOUR-API-KEY', DEBUG=True)
 
 Sendwithus' API typically sends responses back in these ranges:
 
--   2xx – Successful Request
--   4xx – Failed Request (Client error)
--   5xx – Failed Request (Server error)
+-   2xx &emdash; Successful Request
+-   4xx &emdash; Failed Request (Client error)
+-   5xx &emdash; Failed Request (Server error)
 
 If you're receiving an error in the 400 response range follow these steps:
 

--- a/sendwithus/version.py
+++ b/sendwithus/version.py
@@ -1,1 +1,1 @@
-version = '5.2.0'
+version = '5.2.1'

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,9 @@
 from distutils.core import setup
 from setuptools import find_packages
 
-with open('README.md') as fp:
+from io import open
+
+with open('README.md', encoding="utf-8") as fp:
     long_description = fp.read()
 
 setup(
@@ -15,6 +17,7 @@ setup(
     license='LICENSE.txt',
     description='Python API client for sendwithus.com',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     test_suite="sendwithus.test",
     install_requires=[
         "requests >= 2.0.0",

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open('README.md', encoding="utf-8") as fp:
 
 setup(
     name='sendwithus',
-    version='5.2.0',
+    version='5.2.1',
     author='sendwithus',
     author_email='us@sendwithus.com',
     packages=find_packages(),


### PR DESCRIPTION
Add a backwards compatible method to explicitly set the encoding type on the README to prevent bugs like #76 