### PR TITLE
Add a constructor to SendwithusError that stores content

### DIFF
--- a/sendwithus/exceptions.py
+++ b/sendwithus/exceptions.py
@@ -1,6 +1,9 @@
 class SendwithusError(Exception):
     """Base class for Sendwithus API errors"""
 
+    def __init__(self, content=None):
+        self.content = content
+
 
 class AuthenticationError(SendwithusError):
     """API Authentication Failed"""


### PR DESCRIPTION
## Description

Hi! I'm a user of this library and I'd like to make a suggestion to improve user experience around error handling.

## Motivation and Context

As seen below, the `content` is being passed in when creating errors and raising them.

https://github.com/sendwithus/sendwithus_python/blob/45c39c4d3b4f410276f98c23831968e2de4478b4/sendwithus/__init__.py#L153-L158

On the other hand, none of the error classes doesn't implement their constructor.

https://github.com/sendwithus/sendwithus_python/blob/45c39c4d3b4f410276f98c23831968e2de4478b4/sendwithus/exceptions.py#L1-L14

From the library users' perspective, this means they have to access the content of the errors like below, which is a bit error-prone (IndexError) and not very readable. It could be obvious to experienced Python developers who have a good understanding of how built-in `Exception` works internally but I had to spend quite some time to dig into your code to figure this out.

```py
try: 
    api.get_template("INVALID") 
except sendwithus.exceptions.APIError as e: 
    raise MyCustomError(message=e.args[0])                                                                                                                                                                                                                                      
```

So, my suggestion is to add a constructor to `SendwithusError` that stores the content value in its `content` attribute. I think It would be great if the content of the errors could be accessed this way instead.

```py
try: 
    api.get_template("INVALID") 
except sendwithus.exceptions.APIError as e: 
    raise MyCustomError(message=e.content)                                                                                                                                                                                                                                      
```