### PR TITLE
Add optional preheader and AMP fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,8 @@ api.create_template(
     name='Email Name',
     subject='Email Subject',
     html='<html><head></head><body>Valid HTML</body></html>',
-    text='Optional text content'
+    text='Optional text content',
+    preheader='Optional preheader'
 )
 ```
 
@@ -71,7 +72,8 @@ api.create_new_locale(
     version_name='Version Name',
     subject='Email Subject',
     html='<html><head></head><body>Valid HTML</body></html>',
-    text='Optional text content'
+    text='Optional text content',
+    preheader='Optional preheader'
 )
 ```
 
@@ -84,6 +86,7 @@ api.create_new_version(
     subject='Email Subject',
     html='<html><head></head><body>Valid HTML</body></html>',
     text='Optional text content',
+    preheader='Optional preheader',
     locale='fr-FR'
 )
 ```
@@ -97,7 +100,8 @@ api.update_template_version(
     name='Email Name'
     subject='Email Subject',
     html='<html><head></head><body>Valid HTML</body></html>',
-    text='Optional text content'
+    text='Optional text content',
+    preheader='Optional preheader'
 )
 ```
 

--- a/conftest.py
+++ b/conftest.py
@@ -1,10 +1,11 @@
 import pytest
 import sendwithus
+import os
 
 
 @pytest.fixture
 def api_key():
-    return 'PYTHON_API_CLIENT_TEST_KEY'
+    return os.environ.get('SWU_API_KEY')
 
 
 @pytest.fixture
@@ -19,12 +20,15 @@ def api(api_key, api_options):
 
 @pytest.fixture
 def email_id():
-    return 'test_fixture_1'
+    return os.environ.get('TEMPLATE_ID')
 
+@pytest.fixture
+def version_id():
+    return os.environ.get('VERSION_ID')
 
 @pytest.fixture
 def translation_template_id():
-    return 'test_translation_fixture_1'
+    return os.environ.get('TEMPLATE_ID')
 
 
 @pytest.fixture
@@ -34,24 +38,24 @@ def email_address():
 
 @pytest.fixture
 def enabled_drip_campaign_id():
-    return 'dc_Rmd7y5oUJ3tn86sPJ8ESCk'
+    return os.environ.get('DRIP_CAMPAIGN_ID')
 
 
 @pytest.fixture
 def disabled_drip_campaign_id():
-    return 'dc_AjR6Ue9PHPFYmEu2gd8x5V'
+    return os.environ.get('DRIP_CAMPAIGN_DISABLED_ID')
 
 
 @pytest.fixture
 def drip_campaign_step_id():
-    return 'dcs_yaAMiZNWCLAEGw7GLjBuGY'
+    return os.environ.get('DRIP_CAMPAIGN_STEP_ID')
 
 
 @pytest.fixture
 def recipient():
     return {
-        'name': 'Matt',
-        'address': 'us@sendwithus.com'
+        'name': 'Test User',
+        'address': 'person@example.com'
     }
 
 
@@ -67,8 +71,8 @@ def email_data():
 def sender():
     return {
         'name': 'Company',
-        'address': 'company@company.com',
-        'reply_to': 'info@company.com'
+        'address': 'company@example.com',
+        'reply_to': 'info@example.com'
     }
 
 
@@ -76,8 +80,8 @@ def sender():
 def cc_test():
     return [
         {
-            'name': 'Matt CC',
-            'address': 'test+cc@sendwithus.com'
+            'name': 'Test CC',
+            'address': 'test+cc@example.com'
         }
     ]
 
@@ -86,8 +90,8 @@ def cc_test():
 def bcc_test():
     return [
         {
-            'name': 'Matt BCC',
-            'address': 'test+bcc@sendwithus.com'
+            'name': 'Test BCC',
+            'address': 'test+bcc@example.com'
         }
     ]
 

--- a/sendwithus/__init__.py
+++ b/sendwithus/__init__.py
@@ -201,7 +201,7 @@ class api:
         logger.debug('\tresponse code:%s' % r.status_code)
         try:
             logger.debug('\tresponse: %s' % r.json())
-        except:
+        except Exception:
             logger.debug('\tresponse: %s' % r.content)
 
         return self._parse_response(r)
@@ -803,7 +803,7 @@ class BatchAPI(api):
         logger.debug('\tresponse code:%s' % r.status_code)
         try:
             logger.debug('\tresponse: %s' % r.json())
-        except:
+        except Exception:
             logger.debug('\tresponse: %s' % r.content)
 
         return r

--- a/sendwithus/__init__.py
+++ b/sendwithus/__init__.py
@@ -259,6 +259,8 @@ class api:
         subject,
         html,
         text='',
+        preheader=None,
+        amp_html=None,
         timeout=None
     ):
         """ API call to create a template """
@@ -268,6 +270,11 @@ class api:
             'html': html,
             'text': text
         }
+
+        if preheader is not None:
+            payload['preheader'] = preheader
+        if amp_html is not None:
+            payload['amp_html'] = amp_html
 
         return self._api_request(
             self.TEMPLATES_ENDPOINT,
@@ -284,6 +291,8 @@ class api:
         subject,
         text='',
         html='',
+        preheader=None,
+        amp_html=None,
         timeout=None
     ):
         """ API call to create a new locale and version of a template """
@@ -297,6 +306,10 @@ class api:
             payload['html'] = html
         if text:
             payload['text'] = text
+        if preheader is not None:
+            payload['preheader'] = preheader
+        if amp_html is not None:
+            payload['amp_html'] = amp_html
 
         return self._api_request(
             self.TEMPLATES_LOCALES_ENDPOINT % template_id,
@@ -313,6 +326,8 @@ class api:
         template_id=None,
         html=None,
         locale=None,
+        preheader=None,
+        amp_html=None,
         timeout=None
     ):
         """ API call to create a new version of a template """
@@ -329,6 +344,11 @@ class api:
                 'subject': subject,
                 'text': text
             }
+
+        if preheader is not None:
+            payload['preheader'] = preheader
+        if amp_html is not None:
+            payload['amp_html'] = amp_html
 
         if locale:
             url = self.TEMPLATES_SPECIFIC_LOCALE_VERSIONS_ENDPOINT % (
@@ -353,6 +373,8 @@ class api:
         version_id,
         text='',
         html=None,
+        preheader=None,
+        amp_html=None,
         timeout=None
     ):
         """ API call to update a template version """
@@ -369,6 +391,11 @@ class api:
                 'subject': subject,
                 'text': text
             }
+
+        if preheader is not None:
+            payload['preheader'] = preheader
+        if amp_html is not None:
+            payload['amp_html'] = amp_html
 
         return self._api_request(
             self.TEMPLATES_VERSION_ENDPOINT % (template_id, version_id),

--- a/sendwithus/version.py
+++ b/sendwithus/version.py
@@ -1,1 +1,1 @@
-version = '5.2.1'
+version = '5.3.0'

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open('README.md', encoding="utf-8") as fp:
 
 setup(
     name='sendwithus',
-    version='5.2.2',
+    version='5.3.0',
     author='sendwithus',
     author_email='us@sendwithus.com',
     packages=find_packages(),

--- a/test_base.py
+++ b/test_base.py
@@ -47,7 +47,8 @@ def test_create_new_version_success(api, email_id):
         'name{time}'.format(time=time.time()),
         'subject',
         text="Some stuff",
-        template_id=email_id
+        template_id=email_id,
+        preheader='test preheader'
     )
     assert_success(result)
 
@@ -59,6 +60,7 @@ def test_update_template_version(api, email_id, version_id):
         email_id,
         version_id,
         text='Some more stuff',
+        preheader='test preheader'
     )
     assert_success(result)
 
@@ -564,3 +566,24 @@ def test_translation_get(api, translation_tag_test, translation_file_test):
     )
 
     assert 200 == response.status_code
+
+
+def test_create_template_with_preheader(api):
+    """ Test creating a template with a preheader and fetching the result """
+    expected = 'this is a preheader'
+    result = api.create_template(
+        'name',
+        'subject',
+        '<html><head></head><body></body></html>',
+        preheader=expected)
+    assert_success(result)
+
+    id = result.json()['id']
+    result = api.get_template(id)
+    assert_success(result)
+
+    version_id = result.json()['versions'][0]['id']
+    result = api.get_template(id, version_id)
+    assert_success(result)
+
+    assert result.json()['preheader'] == expected

--- a/test_base.py
+++ b/test_base.py
@@ -1,4 +1,3 @@
-import json
 import decimal
 import tempfile
 import time
@@ -22,18 +21,15 @@ def test_get_emails(api):
     assert_success(result)
 
 
-def test_get_template(api):
+def test_get_template(api, email_id):
     """ Test template endpoint. """
-    result = api.get_template("pmaBsiatWCuptZmojWESme")
+    result = api.get_template(email_id)
     assert_success(result)
 
 
-def test_get_template_with_version(api):
+def test_get_template_with_version(api, email_id, version_id):
     """ Test template with version endpoint. """
-    result = api.get_template(
-        'pmaBsiatWCuptZmojWESme',
-        version='ver_pYj27c8DTBsWB4MRsoB2MF'
-    )
+    result = api.get_template(email_id, version_id)
     assert_success(result)
 
 
@@ -46,22 +42,22 @@ def test_create_email_success(api):
     assert_success(result)
 
 
-def test_create_new_version_success(api):
+def test_create_new_version_success(api, email_id):
     result = api.create_new_version(
         'name{time}'.format(time=time.time()),
         'subject',
         text="Some stuff",
-        template_id="pmaBsiatWCuptZmojWESme"
+        template_id=email_id
     )
     assert_success(result)
 
 
-def test_update_template_version(api):
+def test_update_template_version(api, email_id, version_id):
     result = api.update_template_version(
         'name',
         'subject',
-        'pmaBsiatWCuptZmojWESme',
-        'ver_pYj27c8DTBsWB4MRsoB2MF',
+        email_id,
+        version_id,
         text='Some more stuff',
     )
     assert_success(result)
@@ -235,7 +231,7 @@ def test_send_headers_invalid(api, email_id, recipient, email_data):
     assert result.status_code != 200
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def file():
     with tempfile.NamedTemporaryFile() as tempf:
         data = ('simple file content' + '\n') * 3
@@ -246,48 +242,48 @@ def file():
 
 
 def test_send_with_files_valid(api, email_id, recipient, email_data, file):
-        result = api.send(
-            email_id,
-            recipient,
-            email_data=email_data,
-            files=[file])
+    result = api.send(
+        email_id,
+        recipient,
+        email_data=email_data,
+        files=[file])
 
-        assert result.status_code == 200
+    assert result.status_code == 200
 
 
 def test_send_with_inline_valid(api, email_id, recipient, email_data, file):
-        result = api.send(
-            email_id,
-            recipient,
-            email_data=email_data,
-            inline=file)
+    result = api.send(
+        email_id,
+        recipient,
+        email_data=email_data,
+        inline=file)
 
-        assert result.status_code == 200
+    assert result.status_code == 200
 
 
 def test_send_with_files_explicit_filename(api, email_id,
                                            recipient, email_data, file):
-        result = api.send(
-            email_id,
-            recipient,
-            email_data=email_data,
-            files=[{'file': file,
-                    'filename': 'filename.pdf'}]
-        )
+    result = api.send(
+        email_id,
+        recipient,
+        email_data=email_data,
+        files=[{'file': file,
+                'filename': 'filename.pdf'}]
+    )
 
-        assert result.status_code == 200
+    assert result.status_code == 200
 
 
 def test_send_with_inline_explicit_filename(api, email_id,
                                             recipient, email_data, file):
-        result = api.send(
-            email_id,
-            recipient,
-            email_data=email_data,
-            inline={'file': file, 'filename': 'filename.pdf'}
-        )
+    result = api.send(
+        email_id,
+        recipient,
+        email_data=email_data,
+        inline={'file': file, 'filename': 'filename.pdf'}
+    )
 
-        assert result.status_code == 200
+    assert result.status_code == 200
 
 
 def test_send_with_files_valid_1(api, email_id,

--- a/tox.ini
+++ b/tox.ini
@@ -3,12 +3,14 @@ envlist = py{27,34,35,36,37,38}, lint
 skip_missing_interpreters = true
 
 [testenv]
+passenv = *
 deps = .[test]
 commands = py.test -n auto
 
 [testenv:lint]
+passenv = *
 commands =
-    flake8 sendwithus/test_base.py
+    flake8 sendwithus/ test_base.py
     isort --verbose --recursive --diff sendwithus/
     isort --verbose --recursive --check-only sendwithus/
 deps =


### PR DESCRIPTION
Add support for `preheader` and `amp_html` optional fields for template operations

## Description
<!--- Describe your changes in detail if necessary -->
* Add `preheader` and `amp_html` to `create_template`, `create_new_locale`, `create_new_version` and `update_template_version`
* Fixed some tests cases, removed hardcoded resource IDs

## Motivation and Context
Parity with the current Sendwithus API
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
* All new and currently passing tests pass.
* Created a test consumer to verify all affected operations work as expected against test and production environments.
* `amp_html` not yet GA, omitted from test cases.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- See how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
